### PR TITLE
ADS-1133 - Added manage page

### DIFF
--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -30,6 +30,9 @@ module.exports = function bins (dsn_str) {
     { action: 'get', path: '/:uuid/view', route: routes.view.bind(this) },
     { action: 'get', path: '/:uuid/sample', route: routes.sample.bind(this) },
     { action: 'get', path: '/:uuid/log', route: routes.log.bind(this) },
+    // ADS-1133 - Adding new endpoint for manage interface
+    { action: 'get', path: '/manage', route: routes.manage.bind(this) },
+    // This is the default and must be last
     { action: 'all', path: '/:uuid*', route: routes.run.bind(this) }
   ]
 

--- a/lib/routes/bins/manage.js
+++ b/lib/routes/bins/manage.js
@@ -1,0 +1,50 @@
+'use strict'
+
+var debug = require('debug-log')('mockbin')
+var pkg = require('../../../package.json')
+
+module.exports = function (req, res, next) {
+  var self = this
+  res.view = 'bin/manage'
+
+  self.client.keys('bin:*', function (err, ids) {
+    if (err) {
+      debug(err)
+      throw err
+    }
+
+    self.client.multi(
+      ids.map(function (id) { return [ 'lrange', id.replace('bin:', 'log:'), -1, -1 ] })
+    ).exec(function (err, replies) {
+      if (err) {
+        debug(err)
+        throw err
+      }
+
+      res.body = {
+        bin: {
+          version: '1.2',
+          creator: {
+            name: 'mockbin.com',
+            version: pkg.version
+          },
+          entries: []
+        }
+      }
+
+      replies.forEach(function (results, index) {
+        var items
+        if (results.length) {
+          items = results.map(function (str) {
+            return Object.assign(JSON.parse(str), { bin: ids[index], id: ids[index].replace('bin:', '') })
+          })
+        } else {
+          items = [ { bin: ids[index], id: ids[index].replace('bin:', ''), startedDateTime: '<new>' } ]
+        }
+        res.body.bin.entries = res.body.bin.entries.concat(items)
+      })
+
+      next()
+    })
+  })
+}

--- a/lib/routes/ips.js
+++ b/lib/routes/ips.js
@@ -8,7 +8,10 @@ module.exports = {
   },
 
   all: function allIPs (req, res, next) {
-    res.body = req.forwarded.ips
+    res.body =
+        req.forwarded.ips.length
+          ? req.forwarded.ips
+          : req.header('x-forwarded-for').split(/\s*,\s*/)
 
     next()
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "scripts": {
     "start": "node bin/mockbin",
+    "develop": "supervisor -e 'js|jsx|jade|css' bin/mockbin",
     "test": "mocha --recursive",
     "pretest": "standard && echint",
     "coverage": "istanbul cover --dir coverage _mocha -- --recursive --fgrep 'Request Validation' --invert --reporter dot",
@@ -62,10 +63,11 @@
     "cz-conventional-changelog": "^1.1.5",
     "echint": "^1.5.2",
     "mocha": "^2.4.5",
+    "semantic-release": "^6.2.0",
     "should": "^8.2.2",
     "standard": "^6.0.4",
-    "unirest": "^0.4.2",
-    "semantic-release": "^6.2.0"
+    "supervisor": "^0.12.0",
+    "unirest": "^0.4.2"
   },
   "dependencies": {
     "change-case": "^2.3.1",

--- a/src/static/bin/manage.js
+++ b/src/static/bin/manage.js
@@ -1,0 +1,8 @@
+/* globals $ */
+// hljs, FileReader
+
+$(function () {
+  $(document).ready(function () {
+    console.log('Loaded the manage page')
+  })
+})

--- a/src/views/bin/manage.jade
+++ b/src/views/bin/manage.jade
@@ -1,0 +1,64 @@
+extends ../layout.jade
+
+mixin method (method)
+  - var mapping = { GET: 'success', POST: 'primary', PUT: 'info', PATCH: 'warning' , DELETE: 'danger' }
+  - var className = mapping[method] ? mapping[method] : 'default'
+
+  span(class='label-#{className}').label= method
+
+block content
+  div(data-page="bin/manage").container
+
+    h3 Manage Bins #[code= '']
+
+    div.visible-xs
+      a(href= '/bin/manage').btn.btn-block.btn-primary View Details
+
+    hr
+
+    div.alert.alert-warning.visible-xs
+      strong Warning &nbsp;
+      span Best viewed on a desktop screen, with minimum #[code 800px] width.
+
+    table.table.table-hover
+      thead
+        tr
+          th(width='5%')
+          th(width='30%') Id
+          th(width='30%') Description
+          th(width='15%') Used
+          th(width='3%') Lock
+          th(width='10%').text-right Actions
+
+      tbody
+        for entry, id in data.raw.bin.entries
+          tr(data-id= id)
+            td
+              div.btn-group.btn-group-sm
+                a.btn.btn-default(href='/bin/#{entry.id}/view' target='_blank'): i.fa.fa-link
+
+            td.id= entry.id
+
+            td= entry.description || 'Description not set'
+
+            td.date= entry.startedDateTime
+
+            td
+              div.btn-group
+                // should clicking these change the lock status?
+                //+or should this take the user to the edit page?
+                if entry.locked
+                  i.fa.fa-lock
+                else
+                  i.fa.fa-unlock-alt
+
+            td.action.text-right
+              div.btn-group.btn-group-sm
+                // push these into the action button
+                a.btn.btn-default(href='/bin/#{entry.id}/edit'): i.fa.fa-pencil-square
+                a.btn.btn-default(href='/bin/#{entry.id}/delete?redir'): i.fa.fa-trash
+                button.btn.btn-default(data-id= id): i.fa.fa-chevron-down
+
+
+block scripts
+  script(type='text/javascript', src='/static/bin/manage.js')

--- a/src/views/layout.jade
+++ b/src/views/layout.jade
@@ -35,7 +35,7 @@ html
 
           div#navbar.collapse.navbar-collapse
             ul.nav.navbar-nav.navbar-right
-              for link, name in [{name: 'Create Bin', href: '/bin/create'}, {name: 'Docs', href: 'https://github.com/Mashape/mockbin/tree/master/docs'}, {name: 'Github', href: 'https://github.com/Mashape/mockbin'}]
+              for link, name in [{name: 'Create Bin', href: '/bin/create'}, {name: 'Manage Bins', href: '/bin/manage'}, {name: 'Docs', href: 'https://github.com/Mashape/mockbin/tree/master/docs'}, {name: 'Github', href: 'https://github.com/Mashape/mockbin'}]
                 li(class={active: req.originalUrl === link.href}): a(href= link.href)= link.name
 
     block content

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -68,6 +68,7 @@ describe('HTTP', function () {
     })
   })
 
+  /* TODO: Fix */
   it('GET /ips should return proxied IPs', function (done) {
     var req = unirest.get('http://localhost:3000/ips')
 

--- a/test/routes/ips.js
+++ b/test/routes/ips.js
@@ -7,7 +7,7 @@ var ips = require('../../lib/routes/ips')
 require('should')
 
 describe('/ip', function () {
-  it('should response with ip address', function (done) {
+  it('should respond with ip address', function (done) {
     var res = {}
     var req = {
       ip: '0.0.0.0'
@@ -22,7 +22,7 @@ describe('/ip', function () {
 })
 
 describe('/ips', function () {
-  it('should response with all address', function (done) {
+  it('should respond with all address', function (done) {
     var res = {}
     var req = {
       forwarded: {


### PR DESCRIPTION
Added a new page 'manage'

Lists all of the bins that have been created.  For each bin: link to view page, 
id for the bin, description, Last time url was hit, actions for edit, delete, etc

Added new npm target develop for development.  Uses sentinel watching agent
if any js, jsx, jade, css file is change the server will be restarted.

Modified /ids endpoint.  Wasn't passing unit tests.  Modified to use the 
X-forwarded-for if req.forwarded.ips is empty